### PR TITLE
Add fs-extra as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "acorn": "^4.0.4",
-    "amd-name-resolver": "^0.0.6"
+    "amd-name-resolver": "^0.0.6",
+    "fs-extra": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,13 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.0.0.tgz#337352bded4a0b714f3eb84de8cea765e9d37600"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
Was missing previously (but is being used) and causes issues on npm 2 (and in npm@3 if no other packages bring fs-extra).

Fixes #5.