### PR TITLE
Add cwd option to allow relative walks

### DIFF
--- a/lib/dep-files-from-file.js
+++ b/lib/dep-files-from-file.js
@@ -7,20 +7,23 @@ const amdNameResolver = require('amd-name-resolver');
 module.exports = function depFilesFromFile(root, options, _files) {
   let files = _files || [];
   let file = options.entry;
-  let deps = depsFromFile(path.join(root, file));
+  let cwd = options.cwd || '';
+  let deps = depsFromFile(path.join(root, cwd, file));
 
   for (let i = 0; i < deps.length; i++) {
     let dep = deps[i];
     let resolved = amdNameResolver.moduleResolve(dep, file);
     let dependency = resolved + '.js';
+    let fullDependency = cwd ? cwd + '/' + dependency : dependency;
 
     if (Array.isArray(options.external) && options.external.indexOf(resolved) > -1) {
       continue;
     }
 
-    if (files.indexOf(dependency) === -1) {
-      files.push(dependency);
+    if (files.indexOf(fullDependency) === -1) {
+      files.push(fullDependency);
       depFilesFromFile(root, {
+        cwd: cwd,
         entry: dependency,
         external: options.external
       }, files);

--- a/tests/dep-graph-from-file-test.js
+++ b/tests/dep-graph-from-file-test.js
@@ -117,4 +117,48 @@ import y from 'b/c';`,
       ]);
     });
   });
+
+  describe('cwd', function() {
+    beforeEach(function() {
+      fs.removeSync(ROOT);
+      fixturify.writeSync(ROOT + 'cwd/foo', {
+        'foo.js': `
+import x from 'a';
+import y from 'b/c';`,
+        'a.js': ``,
+        'b': {
+          'c.js': `
+      import a from '../a';
+      import d from '../d';
+    `
+        },
+        'd.js': `import foo from 'foo';`
+      });
+    });
+
+    it('extracts', function() {
+      expect(depFilesFromFile(ROOT + 'cwd', { entry: 'foo.js', cwd: 'foo' })).to.eql([
+        'foo/a.js',
+        'foo/b/c.js',
+        'foo/d.js',
+        'foo/foo.js',
+      ]);
+
+      expect(depFilesFromFile(ROOT + 'cwd', { entry: 'a.js', cwd: 'foo' })).to.eql([]);
+
+      expect(depFilesFromFile(ROOT + 'cwd', { entry: 'b/c.js', cwd: 'foo' })).to.eql([
+        'foo/a.js',
+        'foo/d.js',
+        'foo/foo.js',
+        'foo/b/c.js',
+      ]);
+
+      expect(depFilesFromFile(ROOT + 'cwd', { entry: 'd.js', cwd: 'foo' })).to.eql([
+        'foo/foo.js',
+        'foo/a.js',
+        'foo/b/c.js',
+        'foo/d.js',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
This essentially allows you to do a walk from a directory other than the root path you pass in, but all the returned paths will be relative to the root directory.

See tests for more info.